### PR TITLE
Sim working

### DIFF
--- a/meshtastic/deviceonly.options
+++ b/meshtastic/deviceonly.options
@@ -3,6 +3,7 @@
 
 # FIXME pick a higher number someday? or do dynamic alloc in nanopb?
 *DeviceState.node_db max_count:80
+*DeviceState.node_db_neighbors max_count: 80
 
 # FIXME - max_count is actually 32 but we save/load this as one long string of preencoded MeshPacket bytes - not a big array in RAM
 *DeviceState.receive_queue max_count:1

--- a/meshtastic/deviceonly.options
+++ b/meshtastic/deviceonly.options
@@ -2,8 +2,8 @@
 # https://jpa.kapsi.fi/nanopb/docs/reference.html#proto-file-options
 
 # FIXME pick a higher number someday? or do dynamic alloc in nanopb?
-*DeviceState.node_db max_count:80
-*DeviceState.node_db_neighbors max_count: 80
+*DeviceState.node_db max_count:40
+*DeviceState.node_db_neighbors max_count: 40
 
 # FIXME - max_count is actually 32 but we save/load this as one long string of preencoded MeshPacket bytes - not a big array in RAM
 *DeviceState.receive_queue max_count:1

--- a/meshtastic/deviceonly.options
+++ b/meshtastic/deviceonly.options
@@ -3,6 +3,7 @@
 
 # FIXME pick a higher number someday? or do dynamic alloc in nanopb?
 *DeviceState.node_db max_count:80
+*DeviceState.last_sent_by_IDs max_count:80
 
 # FIXME - max_count is actually 32 but we save/load this as one long string of preencoded MeshPacket bytes - not a big array in RAM
 *DeviceState.receive_queue max_count:1

--- a/meshtastic/deviceonly.options
+++ b/meshtastic/deviceonly.options
@@ -3,7 +3,6 @@
 
 # FIXME pick a higher number someday? or do dynamic alloc in nanopb?
 *DeviceState.node_db max_count:80
-*DeviceState.last_sent_by_IDs max_count:80
 
 # FIXME - max_count is actually 32 but we save/load this as one long string of preencoded MeshPacket bytes - not a big array in RAM
 *DeviceState.receive_queue max_count:1

--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -65,12 +65,6 @@ message DeviceState {
    * Some GPSes seem to have bogus settings from the factory, so we always do one factory reset.
    */
   bool did_gps_reset = 11;
-
-  /*
-  * Stores last sent by info in the nodeDB; used by NeighborInfo module
-  */
-  repeated uint32 last_sent_by_IDs = 12; 
-
 }
 
 /*

--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -11,6 +11,7 @@ option swift_prefix = "";
 import "meshtastic/channel.proto";
 import "meshtastic/localonly.proto";
 import "meshtastic/mesh.proto";
+import "meshtastic/neighborinfo.proto";
 
 /*
  * This message is never sent over the wire, but it is used for serializing DB
@@ -65,6 +66,13 @@ message DeviceState {
    * Some GPSes seem to have bogus settings from the factory, so we always do one factory reset.
    */
   bool did_gps_reset = 11;
+
+  /*
+   * Sender information used by NeighborInfo Module to get edge info on the mesh.
+   * This is stored in each node's nodeDB so we'll have a SNR per edge when we sniff packets.
+   * This field should disabled (always zeroed) unless user opts in.
+   */
+  repeated Neighbor node_db_neighbors = 12;
 }
 
 /*

--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -66,6 +66,11 @@ message DeviceState {
    */
   bool did_gps_reset = 11;
 
+  /*
+  * Stores last sent by info in the nodeDB; used by NeighborInfo module
+  */
+  repeated uint32 last_sent_by_IDs = 12; 
+
 }
 
 /*

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -973,6 +973,12 @@ message NodeInfo {
    * The latest device metrics for the node.
    */
   DeviceMetrics device_metrics = 6;
+
+  /*
+  * Stores last sent by info in the nodeDB; used by NeighborInfo module
+  */
+  uint32 last_sent_by_ID = 7; 
+
 }
 
 /*

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -972,7 +972,6 @@ message NodeInfo {
    * The latest device metrics for the node.
    */
   DeviceMetrics device_metrics = 6;
-
 }
 
 /*

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -868,13 +868,12 @@ message MeshPacket {
    */
   Delayed delayed = 13;
 
-    /*
+  /*
    * Sender information used by NeighborInfo Module to get edge info on the mesh.
    * This is stored in each node's nodeDB so we'll have a SNR per edge when we sniff packets.
    * This field should disabled (always zeroed) unless user opts in.
    */
    uint32 last_sent_by_ID = 14;
-
 }
 
 /*
@@ -973,11 +972,6 @@ message NodeInfo {
    * The latest device metrics for the node.
    */
   DeviceMetrics device_metrics = 6;
-
-  /*
-  * Stores last sent by info in the nodeDB; used by NeighborInfo module
-  */
-  uint32 last_sent_by_ID = 7; 
 
 }
 

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -868,6 +868,13 @@ message MeshPacket {
    */
   Delayed delayed = 13;
 
+    /*
+   * Sender information used by NeighborInfo Module to get edge info on the mesh.
+   * This is stored in each node's nodeDB so we'll have a SNR per edge when we sniff packets.
+   * This field should disabled (always zeroed) unless user opts in.
+   */
+   uint32 last_sent_by_ID = 14;
+
 }
 
 /*

--- a/meshtastic/neighborinfo.options
+++ b/meshtastic/neighborinfo.options
@@ -1,0 +1,4 @@
+# options for nanopb
+# https://jpa.kapsi.fi/nanopb/docs/reference.html#proto-file-options
+
+*NeighborInfo.neighbors max_count:10

--- a/meshtastic/neighborinfo.proto
+++ b/meshtastic/neighborinfo.proto
@@ -1,0 +1,47 @@
+syntax = "proto3";
+
+package meshtastic;
+
+option java_package = "com.geeksville.mesh";
+option java_outer_classname = "NeighborInfoProtos";
+option go_package = "github.com/meshtastic/go/generated";
+option csharp_namespace = "Meshtastic.Protobufs";
+option swift_prefix = "";
+
+/*
+* Full info on edges for a single node
+*/
+message NeighborInfo {
+  /*
+  * The node ID of the node sending info on its neighbors
+  */
+  uint32 node_id = 1;
+  /*
+  * Time at packet transmission (in millis, Unix epoch)
+  */
+  fixed32 tx_time = 2;
+
+  /*
+  * A single edge in the mesh
+  */
+  message Neighbor {
+    /*
+    * Node ID of neighbor
+    */
+    uint32 node_id = 1;
+
+    /*
+    * SNR of last heard message
+    */
+    float snr = 2;
+
+    /*
+    * Time of last heard message (in millis, Unix epoch)
+    */
+    fixed32 rx_time = 3;
+  }
+  /*
+  * The list of neighbors
+  */
+  repeated Neighbor neighbors = 4;
+}

--- a/meshtastic/neighborinfo.proto
+++ b/meshtastic/neighborinfo.proto
@@ -22,26 +22,27 @@ message NeighborInfo {
   fixed32 tx_time = 2;
 
   /*
-  * A single edge in the mesh
-  */
-  message Neighbor {
-    /*
-    * Node ID of neighbor
-    */
-    uint32 node_id = 1;
-
-    /*
-    * SNR of last heard message
-    */
-    float snr = 2;
-
-    /*
-    * Time of last heard message (in millis, Unix epoch)
-    */
-    fixed32 rx_time = 3;
-  }
-  /*
   * The list of neighbors
   */
   repeated Neighbor neighbors = 4;
+}
+
+/*
+* A single edge in the mesh
+*/
+message Neighbor {
+  /*
+  * Node ID of neighbor
+  */
+  uint32 node_id = 1;
+
+  /*
+  * SNR of last heard message
+  */
+  float snr = 2;
+
+  /*
+  * Time of last heard message (in millis, Unix epoch)
+  */
+  fixed32 rx_time = 3;
 }

--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -143,6 +143,11 @@ enum PortNum {
   TRACEROUTE_APP = 70;
 
   /*
+   * Aggregates edge info for the network by sending out a list of each node's neighbors
+   */
+  NEIGHBORINFO_APP = 71;
+
+  /*
    * Private applications should use portnums >= 256.
    * To simplify initial development and testing you can use "PRIVATE_APP"
    * in your code without needing to rebuild protobuf files (via [regen-protos.sh](https://github.com/meshtastic/firmware/blob/master/bin/regen-protos.sh))


### PR DESCRIPTION
## Goal
This PR contains the protobuf updates that make the forked firmware work on neighborinfo packets. 

## Implementation
This entails 
- the addition of a NeighborInfo protobuf containing NeighborInfo and Neighbors structs
- the addition of a Neighbors list to the DeviceOnly protobuf for inclusion in the NodeDB 
  - *Note: includes a crude memory limit by halving the node limit (80->40) within the NodeDB*
- the direct addition of a last_Sent_By field to the meshpacket 

These changes are accompanied by a corresponding firmware PR. They are not likely to be breaking on their own (no fields have been removed from protobufs), but result in some memory overhead that isn't advisable if we're not using them in the firmware as well. 

## Notes
- For now, I'm PRing into a remote `development` branch to make it easier to test for breaking changes when we sync the fork.
- Companion PR in the firmware is [here](https://github.com/uhuruhashimoto/firmware/pull/5)

## Development
Issues are not open against this repository, but have been opened against the class repo. This PR will close this issue: 
- [Protobufs Issue](https://app.zenhub.com/workspaces/meshtastic---cosc-098-633f046aebd6cde319822187/issues/gh/dartmouth-cs98/project-22f-meshtastic/101)